### PR TITLE
feat: Add solar system image to page

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,5 +8,6 @@
     <h1>Hello, World!</h1>
     <img src="sprite.png" alt="Sprite" class="sprite">
     <p>This is my first webpage pushed to GitHub!</p>
+    <img src="https://images.pexels.com/photos/2150/sky-space-dark-galaxy.jpg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="Solar System" class="solar-system-image">
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -55,3 +55,14 @@ a:hover {
   border: 2px solid #00c0ff;
   box-shadow: 0 0 15px 5px #00c0ff;
 }
+
+.solar-system-image {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 70%;
+  margin-top: 30px;
+  border: 2px solid #00c0ff;
+  box-shadow: 0 0 15px 5px #00c0ff;
+  border-radius: 10px;
+}


### PR DESCRIPTION
This commit introduces a solar system image to the webpage, positioned below the main text.

Changes include:
- Added an `<img>` tag with class `solar-system-image` to `index.html`.
  - Uses a placeholder image from Pexels.
- Added CSS rules for `.solar-system-image` in `style.css` to:
  - Center the image and make it responsive (`max-width: 70%`).
  - Add top margin for spacing.
  - Apply a border, box-shadow glow, and rounded corners to match the existing sci-fi theme.