### PR TITLE
feat: Add animated side elements and resize image

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,5 +9,19 @@
     <img src="sprite.png" alt="Sprite" class="sprite">
     <p>This is my first webpage pushed to GitHub!</p>
     <img src="https://images.pexels.com/photos/2150/sky-space-dark-galaxy.jpg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="Solar System" class="solar-system-image">
+    <div id="left-animations">
+      <div class="planet"></div>
+      <div class="planet"></div>
+      <div class="planet"></div>
+      <div class="planet"></div>
+      <div class="planet"></div>
+    </div>
+    <div id="right-animations">
+      <div class="flying-saucer"></div>
+      <div class="flying-saucer"></div>
+      <div class="flying-saucer"></div>
+      <div class="flying-saucer"></div>
+      <div class="flying-saucer"></div>
+    </div>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@ body {
   color: #00c0ff;
   font-family: 'Orbitron', sans-serif;
   text-align: center;
-  padding: 60px 20px;
+  padding: 60px 100px; /* Increased side padding */
   margin: 0;
 }
 
@@ -60,9 +60,136 @@ a:hover {
   display: block;
   margin-left: auto;
   margin-right: auto;
-  max-width: 70%;
+  max-width: 50%;
   margin-top: 30px;
   border: 2px solid #00c0ff;
   box-shadow: 0 0 15px 5px #00c0ff;
   border-radius: 10px;
+}
+
+/* Planet Styles */
+.planet {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  margin: 15px 0;
+  animation-name: spin;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+.planet:nth-child(1) {
+  background-color: #4A90E2; /* Blue */
+  animation-duration: 3s;
+}
+
+.planet:nth-child(2) {
+  background-color: #50E3C2; /* Teal */
+  animation-duration: 5s;
+}
+
+.planet:nth-child(3) {
+  background-color: #B8E986; /* Light Green */
+  animation-duration: 4s;
+}
+
+.planet:nth-child(4) {
+  background-color: #F5A623; /* Orange */
+  animation-duration: 6s;
+}
+
+.planet:nth-child(5) {
+  background-color: #D0021B; /* Red */
+  animation-duration: 3.5s;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Flying Saucer Styles */
+.flying-saucer {
+  width: 50px;
+  height: 20px;
+  background-color: silver;
+  border-radius: 50%;
+  margin: 25px 0;
+  position: relative;
+  animation-name: spin;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+.flying-saucer::before {
+  content: "";
+  position: absolute;
+  width: 20px;
+  height: 10px;
+  background-color: darkgrey;
+  border-radius: 50% 50% 0 0;
+  top: -8px; /* Adjusted to sit nicely on top */
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.flying-saucer:nth-child(1) {
+  animation-duration: 2.5s;
+  background-color: #C0C0C0; /* Lighter silver */
+}
+.flying-saucer:nth-child(1)::before {
+  background-color: #A9A9A9; /* Darker grey for dome */
+}
+
+.flying-saucer:nth-child(2) {
+  animation-duration: 4.5s;
+  background-color: #B0B0B0;
+}
+.flying-saucer:nth-child(2)::before {
+  background-color: #999999;
+}
+
+.flying-saucer:nth-child(3) {
+  animation-duration: 3.5s;
+  background-color: #A0A0A0;
+}
+.flying-saucer:nth-child(3)::before {
+  background-color: #898989;
+}
+
+.flying-saucer:nth-child(4) {
+  animation-duration: 5.5s;
+  background-color: #909090;
+}
+.flying-saucer:nth-child(4)::before {
+  background-color: #797979;
+}
+
+.flying-saucer:nth-child(5) {
+  animation-duration: 3s;
+  background-color: #808080; /* Darkest silver/grey */
+}
+.flying-saucer:nth-child(5)::before {
+  background-color: #696969; /* Darkest dome */
+}
+
+/* Animation Container Positioning */
+#left-animations {
+  position: fixed;
+  left: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 50px; /* Approximate width for planets */
+}
+
+#right-animations {
+  position: fixed;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 70px; /* Approximate width for saucers */
 }


### PR DESCRIPTION
This commit introduces animated planets and flying saucers on the sides of the page and resizes the central solar system image.

Key changes:
- Reduced `max-width` of `.solar-system-image` to `50%` in `style.css`.
- Added HTML structure for left and right animation containers (`#left-animations`, `#right-animations`) in `index.html`.
- Populated containers with five `.planet` divs on the left and five `.flying-saucer` divs on the right.
- Styled and animated `.planet` elements in `style.css`:
    - Circular shape, various background colors.
    - CSS `spin` animation with varying durations.
- Styled and animated `.flying-saucer` elements in `style.css`:
    - Elliptical body with a dome (`::before` pseudo-element).
    - Various shades of grey/silver.
    - CSS `spin` animation with varying durations.
- Positioned animation containers (`#left-animations`, `#right-animations`) using `position: fixed` on the sides of the page.
- Adjusted `body` padding in `style.css` to accommodate the new side elements.